### PR TITLE
fix: nft tab responsiveness

### DIFF
--- a/app/app/components/UI/NetworkFee/index.js
+++ b/app/app/components/UI/NetworkFee/index.js
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
 	},
 	tabView: {
 		width: '100%',
-		height: 92
+		minHeight: 92
 	},
 	slider: {
 		flex: 1,

--- a/app/app/components/Views/SendFlow/SendNFTTab/index.js
+++ b/app/app/components/Views/SendFlow/SendNFTTab/index.js
@@ -68,8 +68,7 @@ const styles = StyleSheet.create({
 		margin: 8
 	},
 	container: {
-		marginHorizontal: 30,
-		height: 590
+		marginHorizontal: 30
 	},
 	noteText: {
 		color: colors.$8F92A1,
@@ -142,7 +141,8 @@ const styles = StyleSheet.create({
 	confirmActionWrapper: {
 		flexDirection: 'row',
 		alignItems: 'center',
-		marginBottom: 24
+		marginBottom: 24,
+		marginTop: 24
 	},
 	confirmButton: {
 		flex: 1.4,

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -702,7 +702,7 @@
 		"network": "Network",
 		"unit_price": "Last Price",
 		"created_by": "Created by ",
-		"send_as_gift": "Send as a Gift",
+		"send_as_gift": "Send",
 		"trade_on_openSea": "Trade on OpenSea",
 		"technical_info": "Technical Info",
 		"collection_contract": "Collection Contract",


### PR DESCRIPTION
Changelog

- [x] Fixed a UI bug where the send nft tab would hide part of the button when using larger fonts
- [x] Changed the "send as gift" text from button to just "Send" so it's clearer