### PR TITLE
Hotfix: using better resolution for faviconkit query

### DIFF
--- a/app/app/components/UI/WebsiteIcon/index.js
+++ b/app/app/components/UI/WebsiteIcon/index.js
@@ -73,9 +73,9 @@ export default class WebsiteIcon extends PureComponent {
 		// 	host = host.substr(4);
 		// }
 
-		let iconUrl = `https://api.faviconkit.com/${host}/64`;
+		let iconUrl = `https://api.faviconkit.com/${host}/128`;
 		if (!util.isEtherscanAvailable()) {
-			iconUrl = `https://pali.pollum.cloud/faviconkit/${host}/64`;
+			iconUrl = `https://pali.pollum.cloud/faviconkit/${host}/128`;
 		}
 		return iconUrl;
 	};


### PR DESCRIPTION
Context: 
On sign Tx Hash modal, some dApp icons was in low resolution, so i found that api query that pass 64px for resolution, but this made the image has 32x32 and the modal use 48x48, so i change to 128 to made it to 64x64 to solve the problem